### PR TITLE
Fix getrusage() detection

### DIFF
--- a/configure
+++ b/configure
@@ -12882,11 +12882,12 @@ struct rusage r; getrusage(RUSAGE_SELF, &r)
   ;
   return 0;
 }
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
   CPPFLAGS="$CPPFLAGS -DNO_RUSAGE"
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }

--- a/configure
+++ b/configure
@@ -12874,20 +12874,19 @@ fi
 printf %s "checking for getrusage... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+#include <sys/resource.h>
 int
 main (void)
 {
-getrusage()
+struct rusage r; getrusage(RUSAGE_SELF, &r)
   ;
   return 0;
 }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
   CPPFLAGS="$CPPFLAGS -DNO_RUSAGE"
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AM_CONDITIONAL([ASL_INT64],[test "$intsize" = 64])
 # The critical function for NO_RUSAGE is getrusage(). Use a standard test.
 AC_MSG_CHECKING([for getrusage])
 AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM([#include <sys/resource.h>],[struct rusage r; getrusage(RUSAGE_SELF, &r)])]
+  [AC_LANG_PROGRAM([#include <sys/resource.h>],[struct rusage r; getrusage(RUSAGE_SELF, &r)])],
   [AC_MSG_RESULT([yes])],
   [CPPFLAGS="$CPPFLAGS -DNO_RUSAGE"
    AC_MSG_RESULT([no])])

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AM_CONDITIONAL([ASL_INT64],[test "$intsize" = 64])
 # The critical function for NO_RUSAGE is getrusage(). Use a standard test.
 AC_MSG_CHECKING([for getrusage])
 AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM([[]],[[getrusage()]])],
+  [AC_LANG_PROGRAM([#include <sys/resource.h>],[struct rusage r; getrusage(RUSAGE_SELF, &r)])]
   [AC_MSG_RESULT([yes])],
   [CPPFLAGS="$CPPFLAGS -DNO_RUSAGE"
    AC_MSG_RESULT([no])])


### PR DESCRIPTION
Need to include the header and correct the call. Modern compilers will not report `getrusage()` as being implicitly available.

Also, in the readme there is no mention of needing [BuildTools](https://github.com/coin-or-tools/BuildTools) being necessary in case adjustments in `configure.ac` are necessary. I had to guess and hope I was correct that this was the necessary build dependency.

I used BuildTools' instructions to update the autotools files here.